### PR TITLE
Add plan to tap output

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -314,6 +314,7 @@ ok - test_fake_exports_faked_in_subshells
 ok - test_fake_transmits_params_to_fake_code
 ok - test_fake_transmits_params_to_fake_code_as_array
 ok - test_should_pretty_format_even_when_LANG_is_unset
+1..30
 ```
 
 == How to write tests

--- a/bash_unit
+++ b/bash_unit
@@ -236,25 +236,32 @@ maybe_shuffle() {
 run_tests() {
   local failure=0
 
-  for pending_test in $(set | "$GREP"  -E '^(pending|todo).* \(\)' | "$GREP" -E "$test_pattern" | "$SED" -e 's: .*::')
+  local pending_tests=$(set | "$GREP"  -E '^(pending|todo).* \(\)' | "$GREP" -E "$test_pattern" | "$SED" -e 's: .*::')
+  if [[ -n "$skip_pattern" ]]
+  then
+    local skipped_tests=$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$GREP" -E "$skip_pattern" | "$SED" -e 's: .*::')
+    local tests_to_run="$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$GREP" -v -E "$skip_pattern" | "$SED" -e 's: .*::' | maybe_shuffle)"
+  else
+    local skipped_tests=""
+    local tests_to_run="$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" |  "$SED" -e 's: .*::' | maybe_shuffle)"
+  fi
+
+  local test_count=$(cat "${TEMPFILE}")
+  test_count=$((test_count + $(count "$pending_tests") + $(count "$tests_to_run") + $(count "$skipped_tests")))
+  echo "${test_count}" > "${TEMPFILE}"
+
+  for pending_test in $pending_tests
   do
     notify_test_starting "$pending_test"
     notify_test_pending "$pending_test"
   done
 
-  if [[ -n "$skip_pattern" ]]
-  then
-    for skipped_test in $(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$GREP" -E "$skip_pattern" | "$SED" -e 's: .*::')
-    do
-      notify_test_starting "$skipped_test"
-      notify_test_skipped "$skipped_test"
-    done
-    local tests_to_run="$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$GREP" -v -E "$skip_pattern" | "$SED" -e 's: .*::' | maybe_shuffle)"
-  else
-    local tests_to_run="$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" |  "$SED" -e 's: .*::' | maybe_shuffle)"
-  fi
+  for skipped_test in $skipped_tests
+  do
+    notify_test_starting "$skipped_test"
+    notify_test_skipped "$skipped_test"
+  done
 
-  test_count=$(cat "${TEMPFILE}")
   for test in $tests_to_run
   do
     (
@@ -265,9 +272,7 @@ run_tests() {
       exit $status
     )
     failure=$(( $? || failure))
-    ((test_count++))
   done
-  echo "${test_count}" > "${TEMPFILE}"
 
   return $failure
 }
@@ -484,6 +489,15 @@ skip_if() {
   fi
 }
 
+count() {
+  local tests="$1"
+  if [[ -z "$tests" ]]; then
+    echo 0
+  else
+    echo "$tests" | wc -l
+  fi
+}
+
 output_format=text
 verbosity=normal
 test_pattern=""
@@ -570,13 +584,13 @@ do
   )
   failure=$(( $? || failure))
 done
-  
+
 if ((failure))
 then
-  notify_suites_failed $(cat "${TEMPFILE}")
+  notify_suites_failed "$(cat "${TEMPFILE}")"
 else
-  notify_suites_succeded $(cat "${TEMPFILE}")
+  notify_suites_succeded "$(cat "${TEMPFILE}")"
 fi
 
-unlink $TEMPFILE
+unlink "$TEMPFILE"
 exit $failure

--- a/bash_unit
+++ b/bash_unit
@@ -34,7 +34,13 @@ SED="$(type -P sed)"
 GREP="$(type -P grep)"
 RM="$(type -P rm)"
 SHUF="$(type -P sort) -R"
-TEMPFILE="$(pwd)/$$.tmp"
+
+# Store the number of tests run in a file so that the value is available
+# from the parent process. This will become an issue if we start considering
+# parallel test execution in the future.
+TEST_COUNT_FILE="$(mktemp)"
+# shellcheck disable=2064 # Use single quotes, expands now, not when signaled.
+trap "$RM  -f \"$TEST_COUNT_FILE\"" EXIT
 
 fail() {
   local message=${1:-}
@@ -246,9 +252,9 @@ run_tests() {
     local tests_to_run="$(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" |  "$SED" -e 's: .*::' | maybe_shuffle)"
   fi
 
-  local test_count=$(cat "${TEMPFILE}")
+  local test_count=$(cat "${TEST_COUNT_FILE}")
   test_count=$((test_count + $(count "$pending_tests") + $(count "$tests_to_run") + $(count "$skipped_tests")))
-  echo "${test_count}" > "${TEMPFILE}"
+  echo "${test_count}" > "${TEST_COUNT_FILE}"
 
   for pending_test in $pending_tests
   do
@@ -561,7 +567,7 @@ fi
 
 #run tests received as parameters
 failure=0
-echo 0 > "${TEMPFILE}"
+echo 0 > "${TEST_COUNT_FILE}"
 for test_file in "$@"
 do
   notify_suite_starting "$test_file"
@@ -587,10 +593,9 @@ done
 
 if ((failure))
 then
-  notify_suites_failed "$(cat "${TEMPFILE}")"
+  notify_suites_failed "$(cat "${TEST_COUNT_FILE}")"
 else
-  notify_suites_succeded "$(cat "${TEMPFILE}")"
+  notify_suites_succeded "$(cat "${TEST_COUNT_FILE}")"
 fi
 
-unlink "$TEMPFILE"
 exit $failure

--- a/tests/test_tap_format
+++ b/tests/test_tap_format
@@ -42,13 +42,29 @@ test_tap_format_for_one_pending_test() {
 "\
 # Running tests in code
 ok - pending_not_yet_implemented # todo test to be written
-1..0" \
+1..1" \
 "$(bash_unit_out_for_code <<EOF
   pending_not_yet_implemented() {
     assert false
   }
 EOF
 )"
+}
+
+test_tap_format_with_skipped_tests() {
+  bash_unit_output="$(bash_unit_out_for_code <<EOF
+    test_one() { echo -n ; }
+    test_two() { fail ; }
+    skip_if true two
+EOF
+  )"
+
+  assert_equals "\
+# Running tests in code
+ok - test_two # skip test not run
+ok - test_one
+1..2" \
+  "$bash_unit_output"
 }
 
 test_tap_format_for_failing_test_with_stdout_stderr_outputs() {


### PR DESCRIPTION
Hi @ndavies-om1,

Please accept the following contribution to your PR #131.

This fixes the following issues:
* the documentation did not include your contribution with displaying the plan
* the plan must include skipped/pending tests

I also renamed the variable that points to the file you use to store the test count to `TEST_COUNT_FILE` and used `mktemp` to create it.

Sorry about the delay, I needed to find some descent time slot to give your PR some thoughts.

Best regards,